### PR TITLE
Compatible with the latest version of numpy.

### DIFF
--- a/geatpy/benchmarks/mops/DTLZ5.py
+++ b/geatpy/benchmarks/mops/DTLZ5.py
@@ -51,7 +51,7 @@ class DTLZ5(ea.Problem):  # 继承Problem父类
         P = np.vstack([np.linspace(0, 1, N), np.linspace(1, 0, N)]).T
         P = P / np.tile(np.sqrt(np.sum(P**2, 1, keepdims=True)),
                         (1, P.shape[1]))
-        P = np.hstack([P[:, np.zeros(self.M - 2, dtype=np.int)], P])
+        P = np.hstack([P[:, np.zeros(self.M - 2, dtype=np.int32)], P])
         referenceObjV = P / np.sqrt(2)**np.tile(
             np.hstack([self.M - 2, np.linspace(self.M - 2, 0, self.M - 1)]),
             (P.shape[0], 1))

--- a/geatpy/benchmarks/mops/DTLZ6.py
+++ b/geatpy/benchmarks/mops/DTLZ6.py
@@ -51,7 +51,7 @@ class DTLZ6(ea.Problem):  # 继承Problem父类
         P = np.vstack([np.linspace(0, 1, N), np.linspace(1, 0, N)]).T
         P = P / np.tile(np.sqrt(np.sum(P**2, 1, keepdims=True)),
                         (1, P.shape[1]))
-        P = np.hstack([P[:, np.zeros(self.M - 2, dtype=np.int)], P])
+        P = np.hstack([P[:, np.zeros(self.M - 2, dtype=np.int32)], P])
         referenceObjV = P / np.sqrt(2)**np.tile(
             np.hstack([self.M - 2, np.linspace(self.M - 2, 0, self.M - 1)]),
             (P.shape[0], 1))


### PR DESCRIPTION
The latest numpy has deprecated `np.int`:
```
AttributeError: module 'numpy' has no attribute 'int'.
`np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```