### PR TITLE
修复matplotlib 3.6.3下无法绘制3D散点图问题

### DIFF
--- a/geatpy/visualization/PointScatter.py
+++ b/geatpy/visualization/PointScatter.py
@@ -87,7 +87,7 @@ class PointScatter:
         elif self.Dimension == 3:
             if self.fig is None and self.ax is None:
                 self.fig = plt.figure()  # 生成一块画布
-                self.ax = Axes3D(self.fig)  # 创建绘图区域
+                self.ax = self.fig.add_subplot(111, projection='3d')  # 创建绘图区域
                 self.ax.view_init(elev=30, azim=45)  # 旋转
             for idx, data in enumerate(self.data_set):
                 params = self.params_set[idx]


### PR DESCRIPTION
将self.ax = Axes3D(self.fig)替换为self.ax = self.fig.add_subplot(111, projection='3d'),
解决了在matplotlib 3.6.3版本中无法正常绘制3D散点图的问题。