### PR TITLE
Fix duplicate solutions in the final Pareto solution set and address issues with blank Pareto front plots in newer versions of matplotlib.

### DIFF
--- a/geatpy/Algorithm.py
+++ b/geatpy/Algorithm.py
@@ -512,6 +512,8 @@ class MoeaAlgorithm(Algorithm):  # 多目标优化算法类的父类
             NDSet = pop[np.where(levels == 1)[0]]  # 只保留种群中的非支配个体，形成一个非支配种群
             if NDSet.CV is not None:  # CV不为None说明有设置约束条件
                 NDSet = NDSet[np.where(np.all(NDSet.CV <= 0, 1))[0]]  # 最后要彻底排除非可行解
+            # 排除重复解
+            NDSet = NDSet[np.unique(NDSet.ObjV,return_index=True,axis=0)[1]]
         else:
             NDSet = globalNDSet
         if self.logTras != 0 and NDSet.sizes != 0 and (

--- a/geatpy/visualization/PointScatter.py
+++ b/geatpy/visualization/PointScatter.py
@@ -87,7 +87,8 @@ class PointScatter:
         elif self.Dimension == 3:
             if self.fig is None and self.ax is None:
                 self.fig = plt.figure()  # 生成一块画布
-                self.ax = Axes3D(self.fig)  # 创建绘图区域
+                # self.ax = Axes3D(self.fig)  # 创建绘图区域
+                self.ax = self.fig.add_subplot(111, projection='3d')  # 创建绘图区域
                 self.ax.view_init(elev=30, azim=45)  # 旋转
             for idx, data in enumerate(self.data_set):
                 params = self.params_set[idx]


### PR DESCRIPTION
# pareto前沿图
原项目在绘制3维帕累托前沿图时使用`self.ax = Axes3D(self.fig)`创建绘图区域，但是在目前较高版本中已被弃用，绘制出的3维pareto前沿图空白，而修改为`self.ax = self.fig.add_subplot(111, projection='3d')`可以正常绘制，如下图所示
![pareto前沿图空白](https://daytime001-picturebed.oss-cn-nanjing.aliyuncs.com/typora/pareto%20front.png)
![pareto前沿图_修改后](https://daytime001-picturebed.oss-cn-nanjing.aliyuncs.com/typora/pareto%20front2.png)
# pareto解集中存在重复解
本人在使用`moea_NSGA2_templet`进行多目标问题求解时最终求得的pareto解集中总是会出现重复解，且各个解顺序杂乱，不利于作出决策
![重复解](https://daytime001-picturebed.oss-cn-nanjing.aliyuncs.com/typora/%E9%87%8D%E5%A4%8D%E8%A7%A3.png)
图中两个解的值完全一样(包括后面精确到所有位数)，并且随着种群大小、迭代次数的增多，重复解个数会越来越多
本人通过`NDSet = NDSet[np.unique(NDSet.ObjV,return_index=True,axis=0)[1]]`对重复解进行排除，并且各个解按照大小顺序排列
![无重复解](https://daytime001-picturebed.oss-cn-nanjing.aliyuncs.com/typora/%E6%97%A0%E9%87%8D%E5%A4%8D%E8%A7%A32.png)
